### PR TITLE
Prevent page refresh when selecting availability slot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1794,7 +1794,7 @@
     },
     "com.synconset.imagepicker": {
       "version": "2.1.10",
-      "resolved": "https://npm-mirror.cat.digitalpfizer.com/com.synconset.imagepicker/-/com.synconset.imagepicker-2.1.10.tgz",
+      "resolved": "https://registry.npmjs.org/com.synconset.imagepicker/-/com.synconset.imagepicker-2.1.9.tgz",
       "integrity": "sha512-96p2A/P4/KRbg6rowl0vq1QMhIQh89f6xQ9gkRPMFyrUmgFTlgF7vSEZP6DLqcS1pgJDPcE+ctYLYsWSPpuPYg=="
     },
     "combined-stream": {

--- a/src/pages/availability/availability.ts
+++ b/src/pages/availability/availability.ts
@@ -244,7 +244,7 @@ export class AvailabilityPage {
       let afternoonEnd = moment(this.afternoonEndTime , this.availTimeFmt);
       return afternoonEnd.isBefore(currentTime);
     }
-   
+
   }
 
   public goToHome() {
@@ -395,22 +395,22 @@ export class AvailabilityPage {
     // this.availableAMDates = filtered;
   }
 
-  //Subscribe to availability slots
+  // Subscribe to availability slots
+
   private getAvailabilitySlots(){
-    let _this = this
     this.avail
       .getNumberOfAvailabilitySlots(this.stylistId)
       .snapshotChanges()
       .subscribe(action => {
         console.log('Action: ', action.payload.val());
         if (action.payload.val() == null) {
-          _this.user.setStylistAvailableSlots(
+          this.user.setStylistAvailableSlots(
             firebase.auth().currentUser.uid,
-            _this.defaultAvailableSlots
+            this.defaultAvailableSlots
           )
-          _this.numberOfAvailableSlots = _this.defaultAvailableSlots;
+          this.numberOfAvailableSlots = this.defaultAvailableSlots;
         } else {
-          _this.numberOfAvailableSlots = action.payload.val();
+          this.numberOfAvailableSlots = action.payload.val();
         }
       }, error => {
         console.log('Error: ', error.message);


### PR DESCRIPTION
Using `_this = this;` was refreshing the page upon calling the `toggleSlot()` function, which was calling the lifecycle hooks and showing the spinner again

This PR removes the behaviour and improves the UX